### PR TITLE
Fix command to run a REPL with the java command

### DIFF
--- a/repls.org
+++ b/repls.org
@@ -175,6 +175,14 @@
      2
      user=>
    #+END_SRC
+   
+   Starting from Clojure 1.9.0, ~clojure.spec~ jar needs to be added in the classpath: 
+   
+   #+BEGIN_SRC shell
+     $ java -cp clojure-1.9.0.jar:spec.alpha-0.1.143.jar clojure.main
+     Clojure 1.9.0
+     user=> 
+   #+END_SRC
 
    If you're curious you can find the implementation in [[https://github.com/clojure/clojure/blob/master/src/clj/clojure/main.clj#L174-L266][clojure.main/repl]].
 


### PR DESCRIPTION
Starting from Clojure 1.9.0 the clojure.spec jar is needed to run a REPL.